### PR TITLE
Sets agency ID and author according to the configured SeisComP installation.

### DIFF
--- a/seiscomp/bin/scmlpick
+++ b/seiscomp/bin/scmlpick
@@ -2037,7 +2037,8 @@ class scmlpick(StreamApplication):
         comm.setText(propValue)
         ci = CreationInfo()
         ci.setCreationTime(Time().GMT())
-        ci.setAuthor(self.name())
+        ci.setAgencyID(self.agencyID())
+        ci.setAuthor(self.author())
         comm.setCreationInfo(ci)
         pick.add(comm)
         net_sta = f"{pickData['trace_name'].split('.')[0]}.{pickData['trace_name'].split('.')[1]}"

--- a/seiscomp/etc/defaults/scmlpick.cfg
+++ b/seiscomp/etc/defaults/scmlpick.cfg
@@ -10,7 +10,7 @@ connection.subscriptions = INVENTORY,\
 connection.primaryGroup = PICK
 
 # Defines the author name used to set creationInfo.author in data model objects.
-author = SCMLPICK
+author = @appname@@@@hostname@
 
 # Define the list of channles types that are allowed to process. Example: HH, CH
 whiteChanns = HH, CH, BH


### PR DESCRIPTION
Hi Camilo,
My first PR.
This addition sets the Agency ID and author according to the target system where Scmlpick is being run.
for example:
on the Texnet system.
Agency ID: TEXNET.
Author: scmlpick@hostname.
On my system:
Agency ID: SARAO.
Author: scmlpick@seismoserv1.
This is standard naming for picks and comments in SeisComP.
Hope this is useful.
Chears:
Donavin.
